### PR TITLE
Empty username and password on non-Windows set to a space for anonymous use; typo fix

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -252,7 +252,7 @@ namespace SMBeagle
 
             if (!opts.Quiet)
             {
-                OutputHelper.WriteLine("reachabled hosts with accessible SMB shares:",2);
+                OutputHelper.WriteLine("reachable hosts with accessible SMB shares:",2);
                 foreach (Host host in hf.HostsWithShares)
                     OutputHelper.WriteLine(host.Address,3);
             }

--- a/Program.cs
+++ b/Program.cs
@@ -35,10 +35,15 @@ namespace SMBeagle
             if (! RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // TODO: should we have an enum for exit codes?
-                if (opts.Username == null|| opts.Password == null)
+                if (opts.Username == null)
                 {
-                    OutputHelper.WriteLine("ERROR: Username and Password required on none Windows platforms");
-                    Environment.Exit(1);
+                    OutputHelper.WriteLine("Setting empty Username to \" \" on non-Windows platform (override with -u)");
+                    opts.Username = " ";
+                }
+                if (opts.Password == null)
+                {
+                    OutputHelper.WriteLine("Setting empty Password to \" \" on non-Windows platform (override with -p)");
+                    opts.Password = " ";
                 }
             }
 


### PR DESCRIPTION
Running SMBeagle on Linux, I find myself using `-u " " -p " "` to use anonymous logins when a username/password combination is not known:

```
$ smbeagle -n 10.20.20.0/24 -c out.csv -u " " -p " "
[...]
                         -- SMBeagle v2.4.0 --
[...]
3. Processing manual networks and addresses...
  added network '10.20.20.0/24'
4. Probing hosts and scanning networks for SMB port 445...
  scanning is complete and we have 2 hosts with reachable SMB services
5. Probing SMB services for accessible shares...
Could not list shares from device - ERROR CODE: 'STATUS_ACCESS_DENIED' for host '10.20.20.192'
  probing is complete and we have 1 hosts with accessible shares
    reachabled hosts with accessible SMB shares:
      10.20.20.38
6. Enumerating accessible shares, this can be slow...
6a. Enumerating all subdirectories for known paths
Enumerating all subdirectories for '\\10.20.20.38\shared\' - CTRL-BREAK or CTRL-PAUSE to SKIP                      Enumerating all subdirectories for '\\10.20.20.38\stuff\' - CTRL-BREAK or CTRL-PAUSE to SKIP                       Enumerating all subdirectories for '\\10.20.20.38\scans\' - CTRL-BREAK or CTRL-PAUSE to SKIP                       6b. Splitting large directories to optimise caching and to batch output                                              
6c. Enumerating files in directories
enumerating files in '\\10.20.20.38\shared\' - CTRL-BREAK or CTRL-PAUSE to SKIP                                    enumerating files in '\\10.20.20.38\stuff\' - CTRL-BREAK or CTRL-PAUSE to SKIP                                     enumerating files in '\\10.20.20.38\scans\' - CTRL-BREAK or CTRL-PAUSE to SKIP                                       file enumeration complete, 6 files identified                
7. Completing the writes to CSV or elasticsearch (or both)
 -- AUDIT COMPLETE --
```

Running SMBeagle on non-Windows hosts without `-u` and `-p` generates an error on in v2.4.0, but it seems like defaulting to anonymous login would be a better default.

This patch changes the behavior of SMBeagle to use `" "` as the default for `opts.Username` and `opts.Password`, and changes a small typo.

WARNING: This change is untested; I'm not a C# programmer and I'm not sure how to build for Linux, but this seems like a pretty trivial change.