### PR TITLE
fix: correct spelling of "reachable" in output message

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -249,7 +249,7 @@ namespace SMBeagle
 
             if (!opts.Quiet)
             {
-                OutputHelper.WriteLine("reachabled hosts with accessible SMB shares:",2);
+                OutputHelper.WriteLine("reachable hosts with accessible SMB shares:",2);
                 foreach (Host host in hf.HostsWithShares)
                     OutputHelper.WriteLine(host.Address,3);
             }


### PR DESCRIPTION
Changed `reachabled` to `reachable`